### PR TITLE
Simplify by using viper.SetEnvKeyReplacer

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,6 +89,10 @@ func initializeConfig(cmd *cobra.Command) error {
 	// avoid conflicts.
 	v.SetEnvPrefix(envPrefix)
 
+	// Environment variables can't have dashes in them, so bind them to their equivalent
+	// keys with underscores, e.g. --favorite-color to STING_FAVORITE_COLOR
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
 	// Bind to environment variables
 	// Works great for simple config names, but needs help for names
 	// like --favorite-color which we fix in the bindFlags function
@@ -103,13 +107,6 @@ func initializeConfig(cmd *cobra.Command) error {
 // Bind each cobra flag to its associated viper configuration (config file and environment variable)
 func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		// Environment variables can't have dashes in them, so bind them to their equivalent
-		// keys with underscores, e.g. --favorite-color to STING_FAVORITE_COLOR
-		if strings.Contains(f.Name, "-") {
-			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
-			v.BindEnv(f.Name, fmt.Sprintf("%s_%s", envPrefix, envVarSuffix))
-		}
-
 		// Apply the viper config value to the flag when the flag is not set and viper has a value
 		if !f.Changed && v.IsSet(f.Name) {
 			val := v.Get(f.Name)


### PR DESCRIPTION
Instead of handling the mapping of env keys to config keys explicitly, we can use vipers `SetEnvKeyReplacer` to do the mapping for us, simplifying `bindFlags`.

Passes the tests.